### PR TITLE
Made metrics queries return case sensetive metrics names properly

### DIFF
--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -302,7 +302,7 @@ func (r *MetricsResult) Table(noHeaders bool) (bytes.Buffer, error) {
 		fmt.Fprintln(w, titleRow)
 	}
 	for _, l := range r.LabelValues {
-		row := strings.ToLower(string(l))
+		row := string(l)
 		fmt.Fprintln(w, row)
 	}
 	w.Flush()


### PR DESCRIPTION
All metrics were previously printed out in lowercase format only. Was there a reason you had it set this way before?

Thanks for all your work on this tool, I love it :)