### PR TITLE
Adds Support for mTLS Certs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,13 @@ var rootCmd = &cobra.Command{
 		pql.Auth.Type = viper.GetString("auth-type")
 		pql.Auth.Credentials = config.Secret(viper.GetString("auth-credentials"))
 		pql.Auth.CredentialsFile = viper.GetString("auth-credentials-file")
+		pql.TLSConfig = config.TLSConfig{
+			CAFile: viper.GetString("tls_config.ca_cert_file"),
+			CertFile: viper.GetString("tls_config.cert_file"),
+			KeyFile: viper.GetString("tls_config.key_file"),
+			ServerName: viper.GetString("tls_config.servername"),
+			InsecureSkipVerify: viper.GetBool("tls_config.insecure_skip_verify"),
+		}
 
 		pql.Host = viper.GetString("host")
 		pql.Step = viper.GetString("step")
@@ -72,7 +79,7 @@ var rootCmd = &cobra.Command{
 			pql.Time = t
 		}
 		// Create and set client interface
-		cl, err := promql.CreateClientWithAuth(pql.Host, pql.Auth)
+		cl, err := promql.CreateClientWithAuth(pql.Host, pql.Auth, pql.TLSConfig)
 		if err != nil {
 			errlog.Fatalln(err)
 		}
@@ -160,6 +167,23 @@ func init() {
 	if err := viper.BindPFlag("auth-credentials-file", rootCmd.PersistentFlags().Lookup("auth-credentials-file")); err != nil {
 		errlog.Fatalln(err)
 	}
+	rootCmd.PersistentFlags().String("tls_config.ca_cert_file","","CA cert Path for TLS config")
+	if err := viper.BindPFlag("tls_config.ca_cert_file",rootCmd.PersistentFlags().Lookup("tls_config.ca_cert_file")); err != nil {
+		errlog.Fatalln(err)
+	}
+	rootCmd.PersistentFlags().String("tls_config.cert_file","","client cert Path for TLS config")
+	if err := viper.BindPFlag("tls_config.cert_file",rootCmd.PersistentFlags().Lookup("tls_config.cert_file")); err != nil {
+		errlog.Fatalln(err)
+	}
+	rootCmd.PersistentFlags().String("tls_config.key_file","","client key for TLS config")
+	if err := viper.BindPFlag("tls_config.key_file",rootCmd.PersistentFlags().Lookup("tls_config.key_file")); err != nil {
+		errlog.Fatalln(err)
+	}
+	rootCmd.PersistentFlags().String("tls_config.servername","","server name for TLS config")
+	if err := viper.BindPFlag("tls_config.servername",rootCmd.PersistentFlags().Lookup("tls_config.servername")); err != nil {
+		errlog.Fatalln(err)
+	}
+	rootCmd.PersistentFlags().Bool("tls_config.insecure_skip_verify",false,"disable the TLS verification of server certificates.")
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
This adds client cert support to promcli, allowing queries against a prometheus server behind proxy that requires mtls.

Usage:

```
ppatel4@ppatel4-mbp:[Wed Dec 08 22:06:28]:~/Documents/repos/promql-cli:[main !]$ ./build/bin/darwin/amd64/promql
Error: accepts 1 arg(s), received 0
Usage:
  promql [query_string] [flags]
  promql [command]

Available Commands:
  help        Help about any command
  labels      Get a list of all labels for a given query
  meta        Get the type and help metadata for a metric
  metrics     Get a list of all prometheus metric names

Flags:
      --auth-credentials string           optional auth credentials string for http requests to prometheus
      --auth-credentials-file string      optional path to an auth credentials file for http requests to prometheus
      --auth-type string                  optional auth scheme for http requests to prometheus e.g. "Basic" or "Bearer"
      --config string                     config file location (default $HOME/.promql-cli.yaml)
      --end string                        query range end (either 'now', or an ISO 8601 formatted date string) (default "now")
  -h, --help                              help for promql
      --host string                       prometheus server url (default "http://0.0.0.0:9090")
      --no-headers                        disable table headers for instant queries
      --output string                     override the default output format (graph for range queries, table for instant queries and metric names). Options: json,csv
      --start string                      query range start duration (either as a lookback in h,m,s e.g. 1m, or as an ISO 8601 formatted date string). Required for range queries
      --step string                       results step duration (h,m,s e.g. 1m) (default "1m")
      --time string                       time for instant queries (either 'now', or an ISO 8601 formatted date string) (default "now")
      --timeout string                    the timeout in seconds for all queries (default "10")
      --tls_config.ca_cert_file string    CA cert Path for TLS config
      --tls_config.cert_file string       client cert Path for TLS config
      --tls_config.insecure_skip_verify   disable the TLS verification of server certificates.
      --tls_config.key_file string        client key for TLS config
      --tls_config.servername string      server name for TLS config
  -v, --version                           version for promql

Use "promql [command] --help" for more information about a command.

```