### PR TITLE
targets option

### DIFF
--- a/cmd/targets.go
+++ b/cmd/targets.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/nalbury/promql-cli/pkg/writer"
+	"github.com/spf13/cobra"
+)
+
+var targetsCmd = &cobra.Command{
+	Use:   "targets",
+	Short: "Get a list of configured targets",
+	Long: "Get a list of configured targets",
+	Run: func(cmd *cobra.Command, args []string) {
+		var r writer.SeriesResult
+		result, err := pql.Targets(query)
+		if err != nil {
+			errlog.Fatalln(err)
+		}
+		r = result
+		var m writer.MetricsResult = r.Metrics()
+		if err := writer.WriteInstant(&m, pql.Output, pql.NoHeaders); err != nil {
+			errlog.Fatalln(err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(targetsCmd)
+}
+

--- a/pkg/promql/promql.go
+++ b/pkg/promql/promql.go
@@ -265,3 +265,19 @@ func (p *PromQL) SeriesQuery(query string) ([]model.LabelSet, v1.Warnings, error
 
 	return uniqueMetrics, warnings, err
 }
+
+func (p *PromQL) Targets(query string) ([]model.LabelSet, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), p.TimeoutDuration)
+	defer cancel()
+
+	targets, err := p.Client.Targets(ctx)
+	if nil != err {
+		return []model.LabelSet{}, fmt.Errorf("error querying targets: %v", err)
+	}
+	jobs := make([]model.LabelSet, 0, len(targets.Active))
+	for _, at := range targets.Active {
+		jobs = append(jobs, map[model.LabelName]model.LabelValue{ "__name__": at.Labels["job"] })
+	}
+
+	return jobs, nil
+}


### PR DESCRIPTION
Returns a list of configured targets/jobs from a Prometheus instance. Used with metrics
`promql targets`
metrics
prometheus
node_exporter

`promql node_exporter`
metrics
go_gc_duration_seconds
go_gc_duration_seconds_count
go_gc_duration_seconds_sum
...
