### PR TITLE
deduplicate metric names, set default metric query, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,21 @@ go_memstats_frees_total
 
 ```
 
+A query can be provided to narrow the list of metrics returned, for example to return all metrics that have the string `gc` in their name you can run:
+
+```
+➜  ~ promql metrics '{__name__=~".+gc.+"}'
+METRICS
+go_gc_duration_seconds
+go_gc_duration_seconds_count
+go_gc_duration_seconds_sum
+go_memstats_gc_sys_bytes
+go_memstats_last_gc_time_seconds
+go_memstats_next_gc_bytes
+prometheus_tsdb_head_gc_duration_seconds_count
+prometheus_tsdb_head_gc_duration_seconds_sum
+```
+
 You can also view the metadata information for a metric (or all metrics) with the `promql meta` command.
 
 ```

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,10 +23,13 @@ import (
 // metricsCmd represents the metrics command
 var metricsCmd = &cobra.Command{
 	Use:   "metrics [query_string]",
-	Short: "Get a list of all prometheus metric names",
-	Long:  `Get a list of all prometheus metric names`,
+	Short: "Get a list of prometheus metric names matching the provided query",
+	Long:  `Get a list of prometheus metric names matching the provided query. If no query is provided, all metric names will be returned.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var r writer.SeriesResult
+		if query == "" {
+			query = `{job=~".+"}`
+		}
 		result, warnings, err := pql.SeriesQuery(query)
 		if len(warnings) > 0 {
 			errlog.Printf("Warnings: %v\n", warnings)

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -533,8 +533,8 @@ func (r *SeriesResult) Metrics() MetricsResult {
 	u := make(map[string]struct{})
 	var m MetricsResult
 	for _, l := range *r {
-		if _, ok := u[string(l["__name__"])]; !ok {
-			name := string(l["__name__"])
+		name := string(l["__name__"])
+		if _, ok := u[name]; !ok {
 			u[name] = struct{}{}
 			m = append(m, name)
 		}

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -530,11 +530,16 @@ type SeriesResult []model.LabelSet
 
 // Metrics creates a MetricsResult from a SeriesResult
 func (r *SeriesResult) Metrics() MetricsResult {
-	var metrics MetricsResult = make([]string, 0, len(*r))
+	u := make(map[string]struct{})
+	var m MetricsResult
 	for _, l := range *r {
-		metrics = append(metrics, string(l["__name__"]))
+		if _, ok := u[string(l["__name__"])]; !ok {
+			name := string(l["__name__"])
+			u[name] = struct{}{}
+			m = append(m, name)
+		}
 	}
-	return metrics
+	return m
 }
 
 // WriteInstant writes out the results of the query to an


### PR DESCRIPTION
This PR adds a default query arg of `{job=~".+"}` which should query all metric names when no other query is provided. It also better documents the behavior to address any confusion with the command. (Hopefully closes #30 )

The resulting metric names are also now deduplicated, removing the requirement to pipe things into `sort -u` etc.

